### PR TITLE
Update node which be used in docker image to v16.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   app:
-    image: "node:8-alpine"
+    image: "node:16-alpine"
     user: "node"
     working_dir: /home/goofi
     environment:


### PR DESCRIPTION
## Description
goofi expects node is more than v12.13.1 but node which be used in docker image is v8.
This PR fixes this mismatch.